### PR TITLE
fix: add mfa when requesting aal2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export PWD                := $(shell pwd)
 export BUILD_DATE         := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 export VCS_REF            := $(shell git rev-parse HEAD)
 export QUICKSTART_OPTIONS ?= ""
-export IMAGE_TAG 					:= $(if $(IMAGE_TAG),$(IMAGE_TAG),v1.3.1-4)
+export IMAGE_TAG 					:= $(if $(IMAGE_TAG),$(IMAGE_TAG),v1.3.1-5)
 
 .bin/clidoc:
 	echo "deprecated usage, use docs/cli instead"

--- a/selfservice/flow/login/handler.go
+++ b/selfservice/flow/login/handler.go
@@ -66,6 +66,8 @@ type (
 		ErrorHandlerProvider
 		sessiontokenexchange.PersistenceProvider
 		x.LoggingProvider
+		identity.PrivilegedPoolProvider
+		identity.ManagementProvider
 	}
 	HandlerProvider interface {
 		LoginHandler() *Handler
@@ -213,6 +215,14 @@ func (h *Handler) NewLoginFlow(w http.ResponseWriter, r *http.Request, ft flow.T
 		}
 
 		// Looks like we are requesting an AAL which is higher than what the session has.
+
+		// PLAYTRON: Auto add MFA code method if requesting AAL2 and not existing
+		if updatedIdentity, err := session.AutoAddMFACodeMethod(r.Context(), h.d, sess.Identity.ID, string(f.RequestedAAL)); err != nil {
+			return nil, nil, err
+		} else if updatedIdentity != nil {
+			sess.Identity = updatedIdentity
+		}
+
 		goto preLoginHook
 	}
 

--- a/session/helper.go
+++ b/session/helper.go
@@ -4,8 +4,19 @@
 package session
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+
+	"github.com/ory/herodot"
+	"github.com/ory/kratos/driver/config"
+	"github.com/ory/kratos/identity"
+	"github.com/ory/x/logrusx"
 )
 
 func bearerTokenFromRequest(r *http.Request) (string, bool) {
@@ -16,4 +27,65 @@ func bearerTokenFromRequest(r *http.Request) (string, bool) {
 	}
 
 	return "", false
+}
+
+type MFAAutoAdditionDependencies interface {
+	PrivilegedIdentityPool() identity.PrivilegedPool
+	IdentityManager() *identity.Manager
+	Logger() *logrusx.Logger
+}
+
+// AutoAddMFACodeMethod automatically adds MFA code method to an identity if it doesn't have any
+// when AAL2 is requested or when highest available AAL is requested.
+func AutoAddMFACodeMethod(ctx context.Context, deps MFAAutoAdditionDependencies, identityID uuid.UUID, requestedAAL string) (*identity.Identity, error) {
+	if requestedAAL != config.HighestAvailableAAL && requestedAAL != string(identity.AuthenticatorAssuranceLevel2) {
+		return nil, nil
+	}
+
+	// Fetch the identity with all credentials
+	i, err := deps.PrivilegedIdentityPool().GetIdentity(ctx, identityID, identity.ExpandEverything)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to fetch identity: %s", err))
+	}
+
+	// Check if identity already has MFA code method
+	_, ok := i.GetCredentials(identity.CredentialsTypeCodeAuth)
+	if ok {
+		return i, nil // Already has MFA code method
+	}
+
+	deps.Logger().Infof("Auto-adding MFA code method to identity %s because it does not have any", identityID)
+
+	// Extract email from traits
+	email := gjson.GetBytes(i.Traits, "email").String()
+	if email == "" {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to extract email from identity traits"))
+	}
+
+	// Create code credentials
+	cred := identity.CredentialsCode{
+		Addresses: []identity.CredentialsCodeAddress{
+			{Channel: identity.CodeChannelEmail, Address: email},
+		},
+	}
+	co, err := json.Marshal(&cred)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to encode code credentials to JSON: %s", err))
+	}
+
+	// Add the credentials to the identity
+	i.UpsertCredentialsConfig(identity.CredentialsTypeCodeAuth, co, 0)
+
+	// Update the identity in the database
+	err = deps.IdentityManager().Update(ctx, i, identity.ManagerAllowWriteProtectedTraits)
+	if err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReason("failed to update identity"))
+	}
+
+	// Refresh available AAL
+	if err := deps.IdentityManager().RefreshAvailableAAL(ctx, i); err != nil {
+		return nil, errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReason("failed to refresh available AAL"))
+	}
+
+	return i, nil
 }

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -315,7 +315,7 @@ func (s *ManagerHTTP) DoesSessionSatisfy(ctx context.Context, sess *Session, req
 		return nil
 	}
 
-	if requestedAAL == config.HighestAvailableAAL {
+	if requestedAAL == config.HighestAvailableAAL || requestedAAL == string(identity.AuthenticatorAssuranceLevel2) {
 		// PLAYTRON: Auto add MFA code method if not existing
 		_, ok := sess.Identity.GetCredentials(identity.CredentialsTypeCodeAuth)
 		if !ok {

--- a/session/manager_http.go
+++ b/session/manager_http.go
@@ -5,12 +5,9 @@ package session
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/tidwall/gjson"
 
 	"github.com/ory/kratos/x/nosurfx"
 	"github.com/ory/kratos/x/redir"
@@ -315,37 +312,11 @@ func (s *ManagerHTTP) DoesSessionSatisfy(ctx context.Context, sess *Session, req
 		return nil
 	}
 
-	if requestedAAL == config.HighestAvailableAAL || requestedAAL == string(identity.AuthenticatorAssuranceLevel2) {
-		// PLAYTRON: Auto add MFA code method if not existing
-		_, ok := sess.Identity.GetCredentials(identity.CredentialsTypeCodeAuth)
-		if !ok {
-			s.r.Logger().Infof("Auto-adding MFA code method to identity %s because it does not have any", sess.Identity.ID)
-
-			i, err := s.r.PrivilegedIdentityPool().GetIdentity(ctx, sess.Identity.ID, identity.ExpandEverything)
-			if err != nil {
-				return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to fetch identity: %s", err))
-			}
-
-			email := gjson.GetBytes(i.Traits, "email").String()
-
-			cred := identity.CredentialsCode{Addresses: []identity.CredentialsCodeAddress{{Channel: identity.CodeChannelEmail, Address: email}}}
-			co, err := json.Marshal(&cred)
-			if err != nil {
-				return errors.WithStack(herodot.ErrInternalServerError.WithReasonf("Unable to encode password options to JSON: %s", err))
-			}
-
-			i.UpsertCredentialsConfig(identity.CredentialsTypeCodeAuth, co, 0)
-			err = s.r.IdentityManager().Update(ctx, i, identity.ManagerAllowWriteProtectedTraits)
-			if err != nil {
-				return errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReason("failed to update identity"))
-			}
-
-			if err := s.r.IdentityManager().RefreshAvailableAAL(ctx, i); err != nil {
-				return errors.WithStack(herodot.ErrInternalServerError.WithWrap(err).WithReason("failed to refresh available AAL"))
-			}
-
-			sess.Identity = i
-		}
+	// PLAYTRON: Auto add MFA code method if not existing
+	if updatedIdentity, err := AutoAddMFACodeMethod(ctx, s.r, sess.Identity.ID, requestedAAL); err != nil {
+		return err
+	} else if updatedIdentity != nil {
+		sess.Identity = updatedIdentity
 	}
 
 	managerOpts := &options{}


### PR DESCRIPTION
This adds MFA credential type for users when AAL2 is requested if it has not already been set up for the user.